### PR TITLE
Fix output name for generate

### DIFF
--- a/files/generate/action.yaml
+++ b/files/generate/action.yaml
@@ -15,7 +15,7 @@ inputs:
     description: "Set to true to append to file if it exists already"
     default: "false"
 outputs:
-  path:
+  filepath:
     description: Absolute path to the generated file
 runs:
   using: "node20"


### PR DESCRIPTION
The resulting filepath is stored in `filepath` yet the yaml had the output described as `path`