### PR TITLE
Always pull git lfs even on cache hit

### DIFF
--- a/git/lfs/action.yaml
+++ b/git/lfs/action.yaml
@@ -37,6 +37,5 @@ runs:
         path: .git/lfs
         key: ${{ runner.os }}-${{ inputs.cache-key }}-${{ hashFiles('.lfs-assets-id') }}
         restore-keys: ${{ runner.os }}-${{ inputs.cache-key }}-
-    - if: ${{ steps.lfs-cache.outputs.cache-hit !=  'true' }}
-      shell: bash
+    - shell: bash
       run: git lfs pull


### PR DESCRIPTION
The cache gets restored to `.git/lfs` so you still need to run `git lfs pull` to move the cached files to the correct place. This is also better for partial cache hits.