### PR TITLE
Make Ephemeral Database Lookup Case Insensitive

### DIFF
--- a/ephemeral/database/index.js
+++ b/ephemeral/database/index.js
@@ -27,7 +27,7 @@ class EphemeralClient {
 
   async byName(name) {
     const resp = await this.http.get(`?filters[0].key=name&filters[0].value=${name}`);
-    const record = resp.data.records.filter((record) => record.name.toLocaleLowerCase() === name.toLocaleLowerCase());
+    const record = resp.data.records.filter((record) => record.name.toLowerCase() === name.toLowerCase());
     
     switch (record.length) {
       case 0:

--- a/ephemeral/database/index.js
+++ b/ephemeral/database/index.js
@@ -27,7 +27,7 @@ class EphemeralClient {
 
   async byName(name) {
     const resp = await this.http.get(`?filters[0].key=name&filters[0].value=${name}`);
-    const record = resp.data.records.filter((record) => record.name === name);
+    const record = resp.data.records.filter((record) => record.name.toLocaleLowerCase() === name.toLocaleLowerCase());
     
     switch (record.length) {
       case 0:


### PR DESCRIPTION
The Ephemeral API returns records based off of a case insensitive substring search, but in our action, we filter out records whose names don't match exactly the search string.  

We should make this final filter case insensitive, as we ourselves have been victims of it's case sensitivity.